### PR TITLE
Added swagger documentation to application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # ARISE-MDS sensor portal
  
 This is a shareable version of the ARISE-MDS sensor portal. It is currently a work in progress. This documentation will be updated when the code approaches a release.
+
+For active development please see: https://github.com/jevansbio/ARISE-MDS-sensor-portal/tree/Testing

--- a/sensor_portal/requirements.txt
+++ b/sensor_portal/requirements.txt
@@ -24,6 +24,7 @@ plotly==5.9.0
 django-crispy-forms==1.14.0
 django-autocomplete-light==3.9.4
 crispy-bootstrap5==0.7
+drf-yasg==1.21.10
 #django-recaptcha==3.0.0
 #bagit==1.8.1
 #scikit-image==0.19.3

--- a/sensor_portal/sensor_portal/settings.py
+++ b/sensor_portal/sensor_portal/settings.py
@@ -64,7 +64,9 @@ INSTALLED_APPS = [
     # my apps
     'data_models',
     'user_management',
-    'utils'
+    'utils',
+    # API documentation
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [

--- a/sensor_portal/sensor_portal/urls.py
+++ b/sensor_portal/sensor_portal/urls.py
@@ -17,11 +17,30 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
+from drf_yasg import openapi
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view as swagger_get_schema_view
+
+schema_view = swagger_get_schema_view(
+   openapi.Info(
+      title="Snippets API",
+      default_version='v1',
+      description="Test description",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@snippets.local"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include("frontend_viewer.urls")),
     path("api/", include("data_models.api")),
+    path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     re_path(r"^api-auth/", include("rest_framework.urls",
             namespace="rest_framework"))
 ] + static(settings.FILE_STORAGE_URL, document_root=settings.FILE_STORAGE_ROOT) \


### PR DESCRIPTION
Added swagger API documentation to the application which can be accessed through localhost:8000/swagger/.

- [ ] Check that the endpoint http://localhost:8000/swagger/ works
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/75892731-c7dc-4263-ae6c-03ed68de1bda" />


- [ ] Check that the endpoint http://localhost:8000/redoc/ works
<img width="1420" alt="image" src="https://github.com/user-attachments/assets/09293b93-71a8-4c41-bdc1-23e41566a871" />


- [ ] Check that the endpoint http://localhost:8000/swagger.json/ works
<img width="527" alt="image" src="https://github.com/user-attachments/assets/55998be0-ce17-485f-8cfa-b68e956eae9f" />
